### PR TITLE
Chain call separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ class StaticController
 
     public function actionIndex(): ResponseInterface
     {
-        return $this->responseFactory->createResponse()
+        return $this->responseFactory
+            ->createResponse()
             ->withStatus(Status::OK)
             ->withoutHeader(Header::ACCEPT);
     }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 The package provides:
 
-- Constants for HTTP protocol headers, methods and statuses. All along with short descriptions and RFC links. 
+- Constants for HTTP protocol headers, methods and statuses. All along with short descriptions and RFC links.
 - PSR-7, PSR-17 PhpStorm meta for HTTP protocol headers, methods and statuses.
 - `ContentDispositionHeader` that has static methods to generate `Content-Disposition` header name and value.
 - `HeaderValueHelper` that has static methods to parse the header value parameters.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Readability fix  | according to https://github.com/yiisoft/docs/issues/155, chain calls must be put on separate lines.
----
Found some more.
